### PR TITLE
Bump git to 2.47.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         run: |
           sudo apt-get install shellcheck
@@ -93,7 +93,7 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.targetPlatform }}
           TARGET_ARCH: ${{ matrix.arch }}
       - name: Upload output artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name:
             dugite-native-${{ matrix.targetPlatform }}-${{ matrix.arch }}-output
@@ -106,10 +106,10 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: './artifacts'
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,13 +1,13 @@
 {
   "git": {
-    "version": "v2.45.2",
+    "version": "v2.47.0",
     "packages": [
       {
         "platform": "windows",
         "arch": "amd64",
-        "filename": "PortableGit-2.45.2-64-bit.7z.exe",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.45.2.windows.1/PortableGit-2.45.2-64-bit.7z.exe",
-        "checksum": "851a15074dea6b272785b2a2a4697a72970256de2afe7b8e4a9c5e168c27ccdd"
+        "filename": "PortableGit-2.47.0.2-64-bit.7z.exe",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/PortableGit-2.47.0.2-64-bit.7z.exe",
+        "checksum": "c77368a8f6ccbd43bde0df0ab603133ce885407a018787d6f1971e040590f1ab"
       }
     ]
   },

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -72,7 +72,7 @@ source "$CURRENT_DIR/check-static-linking.sh"
 
 echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
 
-CURL_FILE_NAME="curl-7.61.1"
+CURL_FILE_NAME="curl-7.58.0"
 CURL_FILE="$CURL_FILE_NAME.tar.gz"
 
 cd /tmp || exit 1

--- a/script/build-ubuntu.sh
+++ b/script/build-ubuntu.sh
@@ -31,15 +31,13 @@ case "$TARGET_ARCH" in
     export CC="gcc"
     STRIP="strip"
     HOST=""
-    TARGET=""
-    OSSL_TARGET="linux-x86_64" ;;
+    TARGET="" ;;
   "x86")
     DEPENDENCY_ARCH="x86"
     export CC="i686-linux-gnu-gcc"
     STRIP="i686-gnu-strip"
     HOST="--host=i686-linux-gnu"
-    TARGET="--target=i686-linux-gnu"
-    OSSL_TARGET="linux-generic32" ;;
+    TARGET="--target=i686-linux-gnu" ;;
   "arm64")
     # __GLIBC_MINOR__ is used as a feature test macro.  Replace it with the
     # earliest supported version of glibc 2.17 as was previously the case when building on ubuntu-18.04
@@ -50,15 +48,13 @@ case "$TARGET_ARCH" in
     export CC="aarch64-linux-gnu-gcc"
     STRIP="aarch64-linux-gnu-strip"
     HOST="--host=aarch64-linux-gnu"
-    TARGET="--target=aarch64-linux-gnu"
-    OSSL_TARGET="linux-aarch64" ;;
+    TARGET="--target=aarch64-linux-gnu" ;;
   "arm")
     DEPENDENCY_ARCH="arm"
     export CC="arm-linux-gnueabihf-gcc"
     STRIP="arm-linux-gnueabihf-strip"
     HOST="--host=arm-linux-gnueabihf"
-    TARGET="--target=arm-linux-gnueabihf"
-    OSSL_TARGET="linux-armv4" ;;
+    TARGET="--target=arm-linux-gnueabihf" ;;
   *)
     exit 1 ;;
 esac
@@ -74,62 +70,18 @@ source "$CURRENT_DIR/compute-checksum.sh"
 # shellcheck source=script/check-static-linking.sh
 source "$CURRENT_DIR/check-static-linking.sh"
 
-echo " -- Building vanilla OpenSSL at $OSSL_INSTALL_DIR instead of distro-specific version"
-
-OSSL_FILE_NAME="openssl-1.0.2u"
-OSSL_FILE="$OSSL_FILE_NAME.tar.gz"
-
-cd /tmp || exit 1
-curl -LO "https://www.openssl.org/source/$OSSL_FILE"
-tar -xf $OSSL_FILE
-
-(
-cd $OSSL_FILE_NAME || exit 1
-
-# this will conflict with a variable in the makefile
-unset TARGET_ARCH
-
-# flags:
-# - no-ssl2: deprecated
-# - no-ssl3: deprecated
-# - no-comp: not used by libcurl
-# - no-dso: libcurl won't respect libssl saying it needs -ldl
-# - no-engine: disabled because
-./Configure \
-  "$OSSL_TARGET" \
-  shared \
-  no-ssl2 \
-  no-ssl3 \
-  no-comp \
-  no-dso \
-  no-engine \
-  --prefix="$OSSL_INSTALL_DIR" \
-  --openssldir="$OSSL_INSTALL_DIR"
-
-make depend
-make build_libs
-make install
-)
 echo " -- Building vanilla curl at $CURL_INSTALL_DIR instead of distro-specific version"
 
-CURL_FILE_NAME="curl-7.29.0"
+CURL_FILE_NAME="curl-7.61.1"
 CURL_FILE="$CURL_FILE_NAME.tar.gz"
 
 cd /tmp || exit 1
-curl -LO "https://curl.haxx.se/download/archeology/$CURL_FILE"
+curl -LO "https://curl.haxx.se/download/$CURL_FILE"
 tar -xf $CURL_FILE
 
 (
 cd $CURL_FILE_NAME || exit 1
-
-export LDFLAGS="-Wl,-R$OSSL_INSTALL_DIR/lib"
-
-./configure \
-  --enable-threaded-resolver \
-  --enable-tls-srp \
-  --prefix="$CURL_INSTALL_DIR" \
-  --with-ssl="$OSSL_INSTALL_DIR" \
-  "$HOST" "$TARGET"
+./configure --prefix="$CURL_INSTALL_DIR" "$HOST" "$TARGET"
 make install
 )
 echo " -- Building git at $SOURCE to $DESTINATION"

--- a/script/build.sh
+++ b/script/build.sh
@@ -23,5 +23,4 @@ BASEDIR=$ROOT \
   SOURCE="$ROOT/git" \
   DESTINATION="/tmp/build/git" \
   CURL_INSTALL_DIR="/tmp/build/curl" \
-  OSSL_INSTALL_DIR="/tmp/build/openssl" \
   bash "$SCRIPT"

--- a/script/generate-release-notes.ts
+++ b/script/generate-release-notes.ts
@@ -163,7 +163,7 @@ export default class GenerateReleaseNotes {
       const match = mergeCommitRegex.exec(mergeCommitMessage)
       if (match != null && match.length === 2) {
         const num = parseInt(match[1])
-        if (num != NaN) {
+        if (!Number.isNaN(num)) {
           pullRequestIds.push(num)
         }
       }
@@ -178,7 +178,7 @@ export default class GenerateReleaseNotes {
         pull_number: pullRequestId,
       })
       const { title, number, user } = result.data
-      const entry = ` - ${title} - #${number} via @${user.login}`
+      const entry = ` - ${title} - #${number} via @${user?.login ?? 'unknown'}`
       releaseNotesEntries.push(entry)
     }
 

--- a/script/update-git.ts
+++ b/script/update-git.ts
@@ -203,6 +203,11 @@ async function run() {
     }
   }
 
+  if (!body) {
+    console.log(`🔴 No release notes found for Git for Windows version ${version}`)
+    return
+  }
+
   const package64bit = await getPackageDetails(assets, body, 'amd64')
 
   if (package64bit == null) {

--- a/script/update-git.ts
+++ b/script/update-git.ts
@@ -204,7 +204,9 @@ async function run() {
   }
 
   if (!body) {
-    console.log(`🔴 No release notes found for Git for Windows version ${version}`)
+    console.log(
+      `🔴 No release notes found for Git for Windows version ${version}`
+    )
     return
   }
 


### PR DESCRIPTION
this also restores our targeted curl version to 7.61 since git no longer builds with curl 7.29(I think 7.37 is their new minimum) which isn't suprt important since we don't support centos-7 anymore.